### PR TITLE
Parameterized the client name that is passed to the API

### DIFF
--- a/safebrowsinglookup.py
+++ b/safebrowsinglookup.py
@@ -32,7 +32,7 @@ import httplib
 
 
 class SafebrowsinglookupClient(object):
-    def __init__(self, key='', debug=0, error=0):
+    def __init__(self, key='', name='python', debug=0, error=0):
         """ Create a new client. You must pass your Google API key (http://code.google.com/apis/safebrowsing/key_signup.html).
 
             Arguments:
@@ -41,6 +41,7 @@ class SafebrowsinglookupClient(object):
                 error: Set to 1 to print error output to the standard output. 0 (disabled) by default.
         """
         self.key = key
+        self.name = name
         self.debug = debug
         self.error = error
         self.last_error = ''
@@ -69,7 +70,7 @@ class SafebrowsinglookupClient(object):
                 body = str(body) + "\n" + self.__canonical(str(url))
 
             self.__debug("BODY:\n" + body + "\n\n")
-            url = 'https://sb-ssl.google.com/safebrowsing/api/lookup?client=%s&key=%s&appver=%s&pver=%s' % ('python', self.key, self.version, self.api_version)
+            url = 'https://sb-ssl.google.com/safebrowsing/api/lookup?client=%s&key=%s&appver=%s&pver=%s' % (self.name, self.key, self.version, self.api_version)
             self.__debug("URL: %s" % (url))
 
             response = ''

--- a/safebrowsinglookup.py
+++ b/safebrowsinglookup.py
@@ -37,6 +37,7 @@ class SafebrowsinglookupClient(object):
 
             Arguments:
                 key: API key.
+				name: Set to "yourcompanyname" - something that represents the true identity of the client.
                 debug: Set to 1 to print debug & error output to the standard output. 0 (disabled) by default.
                 error: Set to 1 to print error output to the standard output. 0 (disabled) by default.
         """
@@ -55,7 +56,7 @@ class SafebrowsinglookupClient(object):
     def lookup(self, *urls):
         """ Lookup a list of URLs against the Google Safe Browsing v2 lists.
 
-            Returns a hash <url>: <Gooogle match>. The possible values for <Gooogle match> are: "ok" (no match), "malware", "phishing", "malware,phishing" (match both lists) and "error".
+            Returns a hash <url>: <Gooogle match>. The possible values for <Gooogle match> are: "ok" (no match), "phishing", "malware", "unwanted", "phishing,malware", "phishing,unwanted", "malware,unwanted", "phishing,malware,unwanted" and "error".
 
             Arguments:
                 urls: List of URLs to lookup. The Lookup API allows only 10,000 URL checks a day. If you need more, use the official Google Safe Browsing v2 API implementation (http://code.google.com/p/google-safe-browsing/downloads/list). Each requests must contain 500 URLs at most. The lookup() method will split the list of URLS in blocks of 500 URLs if needed.

--- a/tests/test_safebrowsinglookup.py
+++ b/tests/test_safebrowsinglookup.py
@@ -25,7 +25,7 @@ from safebrowsinglookup import SafebrowsinglookupClient
 
 class SafebrowsinglookupClient_ParseTestCase(unittest.TestCase):
     def setUp(self):
-        self.client = SafebrowsinglookupClient('insert_API_key_here')
+        self.client = SafebrowsinglookupClient('insert_API_key_here', 'insert_client_name_here')
 
     def test_errors(self):
         client = SafebrowsinglookupClient('AAAAAAAAaaAAAaAAAaA0a0AaaAAAAAAa0AaAAAaAa0aaaAaAa0Aa0AaaaA')


### PR DESCRIPTION
The API guide @ https://developers.google.com/safe-browsing/lookup_guide recommends using a meaningful client name.

> Sample URL =
> `https://sb-ssl.google.com/safebrowsing/api/lookup?client=CLIENT&key=APIKEY&appver=APPVER&pver=PVER`
> 
> The client parameter indicates the type of client. You can choose any name. However, _we suggest you choose a name that represents the true identity of the client_, such as “yourcompanyname”.
